### PR TITLE
Fix AnalyzeFile if comment is in the same line as code.

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -80,6 +80,45 @@ class A:
 	}
 }
 
+func TestAnalayzeFile4PythonNoShebang(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "tmp.py")
+	if err != nil {
+		t.Logf("ioutil.TempFile() error. err=[%v]", err)
+		return
+	}
+	defer os.Remove(tmpfile.Name())
+
+	tmpfile.Write([]byte(`a = '''hello
+	world
+	'''
+
+	b = 1
+	"""hello
+	commen
+	"""
+
+	print a, b
+`))
+
+	language := NewLanguage("Python", []string{"#"}, [][]string{{"\"\"\"", "\"\"\""}})
+	clocOpts := NewClocOptions()
+	clocFile := AnalyzeFile(tmpfile.Name(), language, clocOpts)
+	tmpfile.Close()
+
+	if clocFile.Blanks != 2 {
+		t.Errorf("invalid logic. blanks=%v", clocFile.Blanks)
+	}
+	if clocFile.Comments != 3 {
+		t.Errorf("invalid logic. comments=%v", clocFile.Comments)
+	}
+	if clocFile.Code != 5 {
+		t.Errorf("invalid logic. code=%v", clocFile.Code)
+	}
+	if clocFile.Lang != "Python" {
+		t.Errorf("invalid logic. lang=%v", clocFile.Lang)
+	}
+}
+
 func TestAnalayzeFile4Go(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "tmp.go")
 	if err != nil {
@@ -187,6 +226,85 @@ func main() {
 		t.Errorf("invalid logic. code=%v", clocFile.Code)
 	}
 	if clocFile.Lang != "Go" {
+		t.Errorf("invalid logic. lang=%v", clocFile.Lang)
+	}
+}
+
+func TestAnalyzeFile4GoWithNoComment(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "tmp.go")
+	if err != nil {
+		t.Logf("ioutil.TempFile() error. err=[%v]", err)
+		return
+	}
+	defer os.Remove(tmpfile.Name())
+
+	tmpfile.Write([]byte(`package main
+
+	func main() {
+		a := "/*                */"
+		b := "//                  "
+	}
+`))
+
+	language := NewLanguage("Go", []string{"//"}, [][]string{{"/*", "*/"}})
+	clocOpts := NewClocOptions()
+	clocFile := AnalyzeFile(tmpfile.Name(), language, clocOpts)
+	tmpfile.Close()
+
+	if clocFile.Blanks != 1 {
+		t.Errorf("invalid logic. blanks=%v", clocFile.Blanks)
+	}
+	if clocFile.Comments != 0 {
+		t.Errorf("invalid logic. comments=%v", clocFile.Comments)
+	}
+	if clocFile.Code != 5 {
+		t.Errorf("invalid logic. code=%v", clocFile.Code)
+	}
+	if clocFile.Lang != "Go" {
+		t.Errorf("invalid logic. lang=%v", clocFile.Lang)
+	}
+}
+
+func TestAnalyzeFile4JavaWithCommentInCodeLine(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "tmp.java")
+	if err != nil {
+		t.Logf("ioutil.TempFile() error. err=[%v]", err)
+		return
+	}
+	defer os.Remove(tmpfile.Name())
+
+	tmpfile.Write([]byte(`public class Sample {
+		public static void main(String args[]){
+		int a; /* A takes care of counts */
+		int b;
+		int c;
+		String d; /*Just adding comments */
+		bool e; /*
+		comment*/
+		bool f; /*
+		comment1
+		comment2
+		*/
+		/*End of Main*/
+		}
+		}
+`))
+
+	language := NewLanguage("Java", []string{"//"}, [][]string{{"/*", "*/"}})
+	clocOpts := NewClocOptions()
+	clocFile := AnalyzeFile(tmpfile.Name(), language, clocOpts)
+	tmpfile.Close()
+
+	if clocFile.Blanks != 0 {
+		t.Errorf("invalid logic. blanks=%v", clocFile.Blanks)
+	}
+	if clocFile.Comments != 5 {
+		t.Errorf("invalid logic. comments=%v", clocFile.Comments)
+	}
+	if clocFile.Code != 10 {
+		t.Errorf("invalid logic. code=%v", clocFile.Code)
+	}
+	if clocFile.Lang != "Java" {
 		t.Errorf("invalid logic. lang=%v", clocFile.Lang)
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -20,20 +20,22 @@ func trimBOM(line string) string {
 	return line
 }
 
-func containComments(line, commentStart, commentEnd string) bool {
-	inComments := 0
-	for i := 0; i < len(line)-(len(commentStart)-1); i++ {
-		section := line[i : i+len(commentStart)]
-
-		if section == commentStart {
-			inComments++
-		} else if section == commentEnd {
-			if inComments != 0 {
-				inComments--
+func containsComment(line string, multiLines [][]string) bool {
+	for _, mlcomm := range multiLines {
+		for _, comm := range mlcomm {
+			if strings.Contains(line, comm) {
+				return true
 			}
 		}
 	}
-	return inComments != 0
+	return false
+}
+
+func nextRune(s string) rune {
+	for _, r := range s {
+		return r
+	}
+	return 0
 }
 
 func checkMD5Sum(path string, fileCache map[string]struct{}) (ignore bool) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,16 +2,14 @@ package gocloc
 
 import "testing"
 
-func TestContainComments(t *testing.T) {
-	line := "/* hoge */"
-	st := "/*"
-	ed := "*/"
-	if containComments(line, st, ed) {
+func TestContainsComment(t *testing.T) {
+	if !containsComment(`int a; /* A takes care of counts */`, [][]string{{"/*", "*/"}}) {
 		t.Errorf("invalid")
 	}
-
-	line = "/* comment"
-	if !containComments(line, st, ed) {
+	if !containsComment(`bool f; /* `, [][]string{{"/*", "*/"}}) {
+		t.Errorf("invalid")
+	}
+	if containsComment(`}`, [][]string{{"/*", "*/"}}) {
 		t.Errorf("invalid")
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/hhatto/gocloc/issues/12

This PR modifies `AnalyzeReader` function (I believe it simplifies logic).
It also fixes cases where multiline comment exists in the same line as code, e.g.:

```go
var a /* a var */

var b /*
comment
*/
```
