### PR TITLE
File Matching Options

### DIFF
--- a/cmd/gocloc/main.go
+++ b/cmd/gocloc/main.go
@@ -39,6 +39,8 @@ type CmdOptions struct {
 	OutputType     string `long:"output-type" default:"default" description:"output type [values: default,cloc-xml,sloccount,json]"`
 	ExcludeExt     string `long:"exclude-ext" description:"exclude file name extensions (separated commas)"`
 	IncludeLang    string `long:"include-lang" description:"include language name (separated commas)"`
+	Match          string `long:"match" description:"include file name (regex)"`
+	NotMatch       string `long:"not-match" description:"exclude file name (regex)"`
 	MatchDir       string `long:"match-d" description:"include dir name (regex)"`
 	NotMatchDir    string `long:"not-match-d" description:"exclude dir name (regex)"`
 	Debug          bool   `long:"debug" description:"dump debug log for developer"`
@@ -82,12 +84,18 @@ func main() {
 		}
 	}
 
-	// setup option for not match directory
-	if opts.NotMatchDir != "" {
-		clocOpts.ReNotMatchDir = regexp.MustCompile(opts.NotMatchDir)
+	// directory and file matching options
+	if opts.Match != "" {
+		clocOpts.ReMatch = regexp.MustCompile(opts.Match)
+	}
+	if opts.NotMatch != "" {
+		clocOpts.ReNotMatch = regexp.MustCompile(opts.NotMatch)
 	}
 	if opts.MatchDir != "" {
 		clocOpts.ReMatchDir = regexp.MustCompile(opts.MatchDir)
+	}
+	if opts.NotMatchDir != "" {
+		clocOpts.ReNotMatchDir = regexp.MustCompile(opts.NotMatchDir)
 	}
 
 	// setup option for include languages

--- a/option.go
+++ b/option.go
@@ -7,6 +7,8 @@ type ClocOptions struct {
 	SkipDuplicated bool
 	ExcludeExts    map[string]struct{}
 	IncludeLangs   map[string]struct{}
+	ReNotMatch     *regexp.Regexp
+	ReMatch        *regexp.Regexp
 	ReNotMatchDir  *regexp.Regexp
 	ReMatchDir     *regexp.Regexp
 

--- a/utils.go
+++ b/utils.go
@@ -86,12 +86,17 @@ func getAllFiles(paths []string, languages *DefinedLanguages, opts *ClocOptions)
 				return nil
 			}
 
-			// check not-match directory
+			// check match directory & file options
+			if opts.ReNotMatch != nil && opts.ReNotMatch.MatchString(info.Name()) {
+				return nil
+			}
+			if opts.ReMatch != nil && !opts.ReMatch.MatchString(info.Name()) {
+				return nil
+			}
 			dir := filepath.Dir(path)
 			if opts.ReNotMatchDir != nil && opts.ReNotMatchDir.MatchString(dir) {
 				return nil
 			}
-
 			if opts.ReMatchDir != nil && !opts.ReMatchDir.MatchString(dir) {
 				return nil
 			}


### PR DESCRIPTION
Count runtime code with `gocloc --not-match '_test\.go$' .` or simple selection like `gocloc --match vmem src`.