### PR TITLE
Add Dockerfile with linting and testing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,18 @@
+name: docker
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Unshallow
+        run:  git fetch --prune --unshallow
+      - name: Lint Dockerfile
+        run:  docker run --rm -i hadolint/hadolint < Dockerfile
+      - name: Build Docker Container
+        run:  docker build -t gocloc .
+      - name: Test Container
+        run:  docker run -v ${PWD}:/workdir gocloc .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.13-buster AS builder
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+  upx-ucl
+
+WORKDIR /build
+
+COPY . .
+
+RUN GO111MODULE=on CGO_ENABLED=0 go build \
+      -ldflags='-w -s -extldflags "-static"' \
+      -o ./bin/gocloc cmd/gocloc/main.go \
+ && upx-ucl --best --ultra-brute ./bin/gocloc
+
+FROM scratch
+COPY --from=builder /build/bin/gocloc /bin/
+WORKDIR /workdir
+ENTRYPOINT ["/bin/gocloc"]


### PR DESCRIPTION
Container size is minimized by the ldflags (which strip debugging symbols) and compressing via upx.

After merging the PR, it would be nice if the dockerhub cloud builder could be activated to upload to image to Dockerhub for master=latest and $tags.

This then allows to use gocloc e.g. on CI via: `docker run -v ${PWD}:/workdir hhatto/gocloc .` or `docker run -v ${PWD}:/workdir hhatto/gocloc:$VERSION .` (instead of wget $release && $hashcheck && tar -xf .. && chmod +x .. && gocloc .).

Thanks!