### PR TITLE
Add Go 2 alias

### DIFF
--- a/language.go
+++ b/language.go
@@ -138,6 +138,7 @@ var Exts = map[string]string{
 	"f03":         "FORTRAN Modern",
 	"f08":         "FORTRAN Modern",
 	"go":          "Go",
+	"go2":         "Go",
 	"groovy":      "Groovy",
 	"gradle":      "Groovy",
 	"h":           "C Header",


### PR DESCRIPTION
Add `go2` as an alias of "Go" language to get gocloc to recognize `*.go2`.

I've investigated how the difference between Go 1 and 2 affects the current implementation and there should be no breaking changes.

I love to use gocloc every day! Thank you!