### PR TITLE
Correct line comment prefix for TLA+

### DIFF
--- a/language.go
+++ b/language.go
@@ -561,7 +561,7 @@ func NewDefinedLanguages() *DefinedLanguages {
 			"Terra":               NewLanguage("Terra", []string{"--"}, [][]string{{"--[[", "]]"}}),
 			"TeX":                 NewLanguage("TeX", []string{"%"}, [][]string{{"", ""}}),
 			"Isabelle":            NewLanguage("Isabelle", []string{}, [][]string{{"(*", "*)"}}),
-			"TLA":                 NewLanguage("TLA", []string{"/*"}, [][]string{{"(*", "*)"}}),
+			"TLA":                 NewLanguage("TLA", []string{"\\*"}, [][]string{{"(*", "*)"}}),
 			"Tcl/Tk":              NewLanguage("Tcl/Tk", []string{"#"}, [][]string{{"", ""}}),
 			"TOML":                NewLanguage("TOML", []string{"#"}, [][]string{{"", ""}}),
 			"TypeScript":          NewLanguage("TypeScript", []string{"//"}, [][]string{{"/*", "*/"}}),


### PR DESCRIPTION
Line comments in TLA+ are preceded by \*.
See Specifying Systems (https://lamport.azurewebsites.net/tla/book.html), page 32