### PR TITLE
Fix README: add installation in Go version >= 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Inspired by [tokei](https://github.com/Aaronepower/tokei).
 ## Installation
 
 ```
+# Go version >= 1.16
+$ go install github.com/hhatto/gocloc/cmd/gocloc
+
+# Go version < 1.16
 $ go get -u github.com/hhatto/gocloc/cmd/gocloc
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Inspired by [tokei](https://github.com/Aaronepower/tokei).
 
 ```
 # Go version >= 1.16
-$ go install github.com/hhatto/gocloc/cmd/gocloc
+$ go install github.com/hhatto/gocloc/cmd/gocloc@latest
 
 # Go version < 1.16
 $ go get -u github.com/hhatto/gocloc/cmd/gocloc


### PR DESCRIPTION
I followed [this release note](https://tip.golang.org/doc/go1.16#tools) and add README.md to installation for Go version >= 1.16.