### PR TITLE
Make gocloc continue when encountering directory read errors

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -111,7 +111,8 @@ func getAllFiles(paths []string, languages *DefinedLanguages, opts *ClocOptions)
 		vcsInRoot := isVCSDir(root)
 		err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				return err
+				fmt.Printf("%s\n", err)
+				return nil
 			}
 			if ignore := checkDefaultIgnore(path, info, vcsInRoot); ignore {
 				return nil

--- a/utils.go
+++ b/utils.go
@@ -111,7 +111,7 @@ func getAllFiles(paths []string, languages *DefinedLanguages, opts *ClocOptions)
 		vcsInRoot := isVCSDir(root)
 		err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				fmt.Printf("%s\n", err)
+				fmt.Fprintf(os.Stderr, "%s\n", err)
 				return nil
 			}
 			if ignore := checkDefaultIgnore(path, info, vcsInRoot); ignore {


### PR DESCRIPTION
As of right now, gocloc does not return any results if it encounters a directory it cannot read.

Here's my small PoC.
1. Gocloc scanning a clean clone of 'thefuck' repository: https://github.com/nvbn/thefuck/
```bash
$ ./gocloc ~/Documents/Repos/test_cases/gocloc/tests/thefuck/
Results:
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
Python                         404           3591            733          11981
Markdown                         3            138              0            541
JSON                             1              3              0             36
YAML                             1              3              0             22
Plain Text                       1              0              0             11
Bourne Shell                     1              1              0              3
-------------------------------------------------------------------------------
TOTAL                          411           3736            733          12594
-------------------------------------------------------------------------------
```
2. Change permissions of 'tests' directory
```bash
# ls -la 
drwxrwxr-x 8 test test   4096 Sep 13 11:46 tests
# chown root:root tests
# chmod 600 tests
$ cd tests
-bash: cd: tests/: Permission denied
$ ./gocloc ~/Documents/Repos/test_cases/gocloc/tests/thefuck/
fail gocloc analyze. error: open /home/maximillian/Documents/Repos/test_cases/gocloc/tests/thefuck/tests: permission denied
```
It would be nice to have gocloc continue upon read errors. Something like:
```bash
$ ./gocloc ~/Documents/Repos/test_cases/gocloc/tests/thefuck/
open /home/test/Documents/Repos/test_cases/gocloc/tests/thefuck/tests: permission denied
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
Python                         209           1630            470           4658
Markdown                         3            138              0            541
JSON                             1              3              0             36
YAML                             1              3              0             22
Plain Text                       1              0              0             11
Bourne Shell                     1              1              0              3
-------------------------------------------------------------------------------
TOTAL                          216           1775            470           5271
-------------------------------------------------------------------------------
```
Which now shows which directories are denied.

Not a problem with small projects. When using gocloc on larger projects this can cause gocloc to hang for a while before erroring out.

Sorry for hacky solution. I am not proficient in Go.