### PR TITLE
[BUG] fix: semantic error in skip duplicated

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -135,7 +135,7 @@ func getAllFiles(paths []string, languages *DefinedLanguages, opts *ClocOptions)
 						}
 					}
 
-					if !opts.SkipDuplicated {
+					if opts.SkipDuplicated {
 						ignore := checkMD5Sum(path, fileCache)
 						if ignore {
 							if opts.Debug {


### PR DESCRIPTION
The default operations in `gocloc` will consider the same files as only one file, which will leads to confusion.


And I find the flag is wrong.