### PR TITLE
Add --fullpath option

### DIFF
--- a/cmd/gocloc/main.go
+++ b/cmd/gocloc/main.go
@@ -50,6 +50,7 @@ type CmdOptions struct {
 	NotMatch       string `long:"not-match" description:"exclude file name (regex)"`
 	MatchDir       string `long:"match-d" description:"include dir name (regex)"`
 	NotMatchDir    string `long:"not-match-d" description:"exclude dir name (regex)"`
+	Fullpath       bool   `long:"fullpath" description:"apply match/not-match options to full file paths instead of base names"`
 	Debug          bool   `long:"debug" description:"dump debug log for developer"`
 	SkipDuplicated bool   `long:"skip-duplicated" description:"skip duplicated files"`
 	ShowLang       bool   `long:"show-lang" description:"print about all languages and extensions"`
@@ -289,6 +290,7 @@ func main() {
 
 	clocOpts.Debug = opts.Debug
 	clocOpts.SkipDuplicated = opts.SkipDuplicated
+	clocOpts.Fullpath = opts.Fullpath
 
 	processor := gocloc.NewProcessor(languages, clocOpts)
 	result, err := processor.Analyze(paths)

--- a/option.go
+++ b/option.go
@@ -12,6 +12,7 @@ type ClocOptions struct {
 	ReMatch        *regexp.Regexp
 	ReNotMatchDir  *regexp.Regexp
 	ReMatchDir     *regexp.Regexp
+	Fullpath       bool
 
 	// OnCode is triggered for each line of code.
 	OnCode func(line string)

--- a/utils.go
+++ b/utils.go
@@ -82,10 +82,15 @@ func checkDefaultIgnore(path string, info os.FileInfo, isVCS bool) bool {
 
 func checkOptionMatch(path string, info os.FileInfo, opts *ClocOptions) bool {
 	// check match directory & file options
-	if opts.ReNotMatch != nil && opts.ReNotMatch.MatchString(info.Name()) {
+	targetFile := info.Name()
+	if opts.Fullpath {
+		targetFile = path
+	}
+
+	if opts.ReNotMatch != nil && opts.ReNotMatch.MatchString(targetFile) {
 		return false
 	}
-	if opts.ReMatch != nil && !opts.ReMatch.MatchString(info.Name()) {
+	if opts.ReMatch != nil && !opts.ReMatch.MatchString(targetFile) {
 		return false
 	}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -105,4 +105,42 @@ func TestCheckOptionMatch(t *testing.T) {
 	if !checkOptionMatch("/thisisdir/one.go", fi, opts) {
 		t.Errorf("invalid logic: renotmatchdir is not ignore")
 	}
+
+	t.Run("--match option", func(t *testing.T) {
+		opts = &ClocOptions{
+			ReMatch: regexp.MustCompile("app.py"),
+		}
+		fi = MockFileInfo{FileName: "app.py", IsDirectory: false}
+		if !checkOptionMatch("test_dir/app.py", fi, opts) {
+			t.Errorf("invalid logic: match is not ignore")
+		}
+	})
+
+	t.Run("--match option with --fullpath option", func(t *testing.T) {
+		opts = &ClocOptions{
+			ReMatch:  regexp.MustCompile("test_dir/app.py"),
+			Fullpath: true,
+		}
+		fi = MockFileInfo{FileName: "app.py", IsDirectory: false}
+		if !checkOptionMatch("test_dir/app.py", fi, opts) {
+			t.Errorf("invalid logic: match(with fullpath) is not ignore")
+		}
+		if checkOptionMatch("app.py", fi, opts) {
+			t.Errorf("invalid logic: match(with fullpath) is ignore")
+		}
+	})
+
+	t.Run("--not-match option with --fullpath option", func(t *testing.T) {
+		opts = &ClocOptions{
+			ReNotMatch: regexp.MustCompile("test_dir/app.py"),
+			Fullpath:   true,
+		}
+		fi = MockFileInfo{FileName: "app.py", IsDirectory: false}
+		if checkOptionMatch("test_dir/app.py", fi, opts) {
+			t.Errorf("invalid logic: not-match(with fullpath) is ignore")
+		}
+		if !checkOptionMatch("app.py", fi, opts) {
+			t.Errorf("invalid logic: not-match(with fullpath) is not ignore")
+		}
+	})
 }


### PR DESCRIPTION
Added `--fullpath` option to be enabled for the `--match` and `--not-match` options.
While `--match` / `--not-match` options determined regex matches/not-matches only for basenames.
When `--fullpath` option is specified, match/not-match are determined for the entire file path.

ref: #93 