### PR TITLE
feat: output-type markdown

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -5,8 +5,27 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
+
+func InsertPipesInTheMiddle(input string) string {
+	var output strings.Builder
+	re := regexp.MustCompile(`\s+`)
+	words := strings.Fields(input)
+	spaces := re.FindAllString(input, -1)
+
+	for i := 0; i < len(words); i++ {
+		if i < len(spaces) {
+			middle := (len(spaces[i]) / 2) - 1
+			output.WriteString(words[i] + strings.Repeat(" ", middle) + "|" + strings.Repeat(" ", middle))
+		} else {
+			output.WriteString(words[i] + " |")
+		}
+	}
+
+	return output.String()
+}
 
 func trimBOM(line string) string {
 	l := len(line)


### PR DESCRIPTION
+ Extend the output format to a markdown table, allowing to show results in the `Github action's workflow summary`

--> --output-type=                         output type [values: default,**markdown**,cloc-xml,sloccount,json] (default: default)

I started to use this go program recently on my Github Action Workflows, and I did a `bash hack` to convert the `--output-type=default` output to `Markdown table`

My hack is:

```yaml
      - name: Lines of code
        run: |
          echo "## Line of code" >> $GITHUB_STEP_SUMMARY

          go install github.com/hhatto/gocloc/cmd/gocloc@latest
          gocloc --not-match-d=vendor,bin,build,dist,docs,examples,scripts,testdata,tests,tools . \
          | tail -n +2 | sed -e '$ d' | sed 's/^/|/' | sed 's/ \{1,\}/  \|  /g' | sed 's/$/\|/' | tac |sed '2d'| tac | sed 's/---\{5,20\}/--|--/g' \
          | tee -a $GITHUB_STEP_SUMMARY
```

To show it as:

![Screenshot 2025-02-04 at 14 46 20](https://github.com/user-attachments/assets/4fb80da0-f4e7-46da-8b0f-77df728592ae)

As a hack, this is fine, but the columns were not aligned as expected, so I decided to make this pull request to do that natively in the code, so now this is the result:

![Screenshot 2025-02-04 at 14 47 44](https://github.com/user-attachments/assets/2921f5b4-3931-4666-a0b4-83619f507cb5)

I hope this will be util and accepted


 