### PR TITLE
Add total column for md and default

### DIFF
--- a/cmd/gocloc/main.go
+++ b/cmd/gocloc/main.go
@@ -318,6 +318,7 @@ func (o *outputBuilder) WriteResult() {
 		}
 	}
 
+	// write footer
 	o.WriteFooter()
 }
 

--- a/cmd/gocloc/main.go
+++ b/cmd/gocloc/main.go
@@ -153,7 +153,7 @@ func (o *outputBuilder) WriteFooter() {
 		} else {
 			fmt.Printf("| %21v|%22v|%12v|%14v|%12v|%9v |\n", "", "", "", "", "", "")
 			fmt.Printf(
-				"| %20v |%21v |%11v |%13v |%11v |%9v |\n",
+				"| %-20v |%21v |%11v |%13v |%11v |%9v |\n",
 				"TOTAL", total.Total, total.Blanks, total.Comments, total.Code, totalLines,
 			)
 		}
@@ -293,7 +293,7 @@ func (o *outputBuilder) WriteResult() {
 			for _, language := range sortedLanguages {
 				totalLines := language.Blanks + language.Comments + language.Code
 				fmt.Printf(
-					"| %20v |%21v |%11v |%13v |%11v |%9v |\n",
+					"| %-20v |%21v |%11v |%13v |%11v |%9v |\n",
 					language.Name,
 					len(language.Files),
 					language.Blanks,

--- a/cmd/gocloc/main.go
+++ b/cmd/gocloc/main.go
@@ -144,20 +144,16 @@ func (o *outputBuilder) WriteFooter() {
 	if o.opts.OutputType == OutputTypeMarkdown {
 		totalLines := total.Blanks + total.Comments + total.Code
 		if o.opts.ByFile {
-			// empty-row separator
+			fmt.Printf("| %-[1]*[2]v |%10v|%12v|%14v|%12v|%9v |\n", maxPathLen, "", "", "", "", "", "") // empty-row separator
+			// totals
 			fmt.Printf(
-				"| %-[1]*[2]v |%10v|%12v|%14v|%14v|%8v |\n",
-				maxPathLen, "", "", "", "", "",
-			)
-			// actual totals
-			fmt.Printf(
-				"| %-[1]*[2]v |%9v |%11v |%13v |%13v |%8v |\n",
+				"| %-[1]*[2]v |%9v |%11v |%13v |%11v |%9v |\n",
 				maxPathLen, "TOTAL", total.Total, total.Blanks, total.Comments, total.Code, totalLines,
 			)
 		} else {
-			fmt.Printf("| %21v|%22v|%12v|%14v|%14v|%8v |\n", "", "", "", "", "", "")
+			fmt.Printf("| %21v|%22v|%12v|%14v|%12v|%9v |\n", "", "", "", "", "", "")
 			fmt.Printf(
-				"| %20v |%21v |%11v |%13v |%13v |%8v |\n",
+				"| %20v |%21v |%11v |%13v |%11v |%9v |\n",
 				"TOTAL", total.Total, total.Blanks, total.Comments, total.Code, totalLines,
 			)
 		}
@@ -224,7 +220,7 @@ func writeResultWithByFile(opts *CmdOptions, result *gocloc.Result) {
 			clocFile := file
 			totalLines := clocFile.Blanks + clocFile.Comments + clocFile.Code
 			fmt.Printf(
-				"| %-[1]*[2]s | %6v | %8v | %10v | %12v | %8v |\n",
+				"| %-[1]*[2]s |%9[3]v |%11[4]v |%13[5]v |%11[6]v |%8[7]v  |\n",
 				maxPathLen,
 				file.Name,
 				1, // files count per-file is always 1
@@ -297,7 +293,7 @@ func (o *outputBuilder) WriteResult() {
 			for _, language := range sortedLanguages {
 				totalLines := language.Blanks + language.Comments + language.Code
 				fmt.Printf(
-					"| %-20v | %6v | %8v | %10v | %12v | %8v |\n",
+					"| %20v |%21v |%11v |%13v |%11v |%9v |\n",
 					language.Name,
 					len(language.Files),
 					language.Blanks,
@@ -322,7 +318,6 @@ func (o *outputBuilder) WriteResult() {
 		}
 	}
 
-	// write footer
 	o.WriteFooter()
 }
 


### PR DESCRIPTION
This pr does the following:
- adds a total column at the end of the table for md and default output.
- simplify code for printing seperator lines
- fix spacing of files column


I tested on the gocloc repo with the following results:

## default
<img width="667" height="190" alt="Screenshot 2025-07-25 160912" src="https://github.com/user-attachments/assets/c45f1f81-a261-4ec6-9b32-81214430d282" />

<img width="674" height="438" alt="Screenshot 2025-07-25 160953" src="https://github.com/user-attachments/assets/31fc7434-f17f-4fe2-ac44-0bdffc2f45ba" />


## markdown
<img width="705" height="168" alt="Screenshot 2025-07-25 161105" src="https://github.com/user-attachments/assets/62793ac7-c08d-4618-a9bf-6e9a8946a098" />

<img width="666" height="409" alt="Screenshot 2025-07-25 161044" src="https://github.com/user-attachments/assets/0909499a-04c2-4fed-9d13-336d2132ea16" />


---


Additional comments:
- adding the total column made me realize that gocloc does not count all lines, with the total value being 1 less than the length of files. I am not sure if this is intended, so I wanted to mention it
- xml and json was not implemented, but wanted to get this out as a progressive enhancement
- when using gocloc on the gocloc repo I realized that for some reason gocloc by default excludes some folders. this seems to be the case for the .github folder as seen in the following output:

<img width="557" height="434" alt="Screenshot 2025-07-25 162549" src="https://github.com/user-attachments/assets/b1109a28-3b7a-430e-aa7c-e07fd73c827c" />

<img width="655" height="534" alt="Screenshot 2025-07-25 162537" src="https://github.com/user-attachments/assets/4ad522f0-67f9-4b7f-b3e3-02615f5e2a78" />

