### PR TITLE
Fix scanner 1mb line-limit

### DIFF
--- a/file.go
+++ b/file.go
@@ -87,15 +87,13 @@ func AnalyzeReader(filename string, language *Language, file io.Reader, opts *Cl
 
 scannerloop:
 	for {
-		// lineBytes, err := reader.ReadBytes('\n')
 		lineOrg, err := reader.ReadString('\n')
 		if err != nil && err != io.EOF {
 			fmt.Printf("ERROR - could not read file (-> skip): %v\n", err)
 			break
 		}
 
-		// If the file does not end with newline, lineBytes may not end in \n
-		// without this we get infinite loop
+		// prevent infinite loop
 		if len(lineOrg) == 0 && err == io.EOF {
 			break
 		}
@@ -204,7 +202,7 @@ scannerloop:
 		}
 
 		if err == io.EOF {
-			break // End of file
+			break
 		}
 	}
 


### PR DESCRIPTION
closes #81

performance with time is basicly identical

tested with this 1.5mb file
[test_long_line.txt](https://github.com/user-attachments/files/21440639/test_long_line.txt)

Result Before/After:
## Before
<img width="564" height="245" alt="before" src="https://github.com/user-attachments/assets/798aa798-00a9-4616-9437-f1bce70f2128" />


## After
<img width="565" height="249" alt="after" src="https://github.com/user-attachments/assets/7e46bdfb-a139-44ec-bac2-bc3346d15486" />


